### PR TITLE
Fix code scanning alert no. 3: Insecure randomness

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -43,9 +43,11 @@ export function getLocalStorage(key: string) {
   return [];
 }
 
+import { randomBytes } from 'crypto';
+
 export function generateUUID(): string {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
+    const r = randomBytes(1)[0] % 16;
     const v = c === 'x' ? r : (r & 0x3) | 0x8;
     return v.toString(16);
   });


### PR DESCRIPTION
Fixes [https://github.com/athrael-soju/ai-chatbot/security/code-scanning/3](https://github.com/athrael-soju/ai-chatbot/security/code-scanning/3)

To fix the problem, we need to replace the use of `Math.random()` in the `generateUUID` function with a cryptographically secure random number generator. In Node.js, we can use the `crypto` module to achieve this. Specifically, we can use `crypto.randomBytes` to generate secure random bytes and then convert these bytes to a hexadecimal string to form the UUID.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
